### PR TITLE
added tests to achieve adequate coverage on ReflectionService

### DIFF
--- a/src/main/java/core/ReflectionService.java
+++ b/src/main/java/core/ReflectionService.java
@@ -64,14 +64,12 @@ public class ReflectionService {
      */
     private String checkFormat(String className) throws InvalidFormatException {
         String pathToClass = classSource + className;
-        Pattern pathPatternToClass = Pattern.compile("([\\w]+\\.?)+");
-        Matcher matcher = pathPatternToClass.matcher(pathToClass);
-        if (matcher.find()) {
+        String regex = "([[A-Za-z0-9_-]]+\\.?)+";
+        if (pathToClass.matches(regex)) {
             return pathToClass;
         } else {
             throw new InvalidFormatException();
         }
-
     }
 
     public String getClassSource() {

--- a/src/test/java/core/ReflectionServiceTest.java
+++ b/src/test/java/core/ReflectionServiceTest.java
@@ -5,13 +5,12 @@ import java.awt.*;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 /**
  * A test suite for the Reflection service
  */
-public class ReflectorTest {
+public class ReflectionServiceTest {
 
     @Test
     public void testReflectNoArgsConstructor() {
@@ -78,5 +77,45 @@ public class ReflectorTest {
     public void testGetClassSource() {
         ReflectionService reflector = new ReflectionService("metrics.comparison.");
         assertEquals("Class source obtained from reflector is incorrect.", "metrics.comparison.", reflector.getClassSource());
+    }
+
+    @Test
+    /**
+     * test for when reflection is invoked with a malformed pathname.
+     * an InvalidFormat Exception should be thrown
+     */
+    public void testInvalidPathFormatNoArgs(){
+        ReflectionService reflector = new ReflectionService();
+        reflector.setClassSource("metrics,comparison,");
+        Object instance = null;
+        String className = "CommonElements";
+
+        try {
+            instance = reflector.loadClass(className);
+            fail();
+        } catch (Exception e) {
+            assertTrue(e instanceof InvalidFormatException);
+        }
+    }
+
+    @Test
+    /**
+     * test for when reflection is invoked with a malformed pathname.
+     * an InvalidFormat Exception should be thrown
+     */
+    public void testInvalidPathFormatArgs(){
+        ReflectionService reflector = new ReflectionService("java/awt/");
+
+        Object instance = null;
+        String className = "Rectangle";
+        Class[] constructorTemplate = new Class[] {int.class, int.class};
+        Object[] constructorValues = new Object[] {5, 10};
+
+        try {
+            instance = reflector.loadClass(className, constructorTemplate, constructorValues);
+            fail();
+        } catch (Exception e) {
+            assertTrue(e instanceof InvalidFormatException);
+        }
     }
 }


### PR DESCRIPTION
The tests for the reflector did not include a test for when the class path was improperly formatted. Tests have been added that achieve this