### PR TITLE
removed the checkFormat method from data representations

### DIFF
--- a/src/main/java/data_representation/CSV.java
+++ b/src/main/java/data_representation/CSV.java
@@ -48,7 +48,8 @@ public class CSV implements DataRepresentation {
 
 	@Override
 	public void parse(String s) throws InvalidFormatException {
-		if(this.checkFormat(s)) {
+		//this regex checks that a string is one or more groups of non-newline characters, separated by commas
+		if(s.matches("(.+?)(?:,\\s*|$)")) {
 			this.testcase = s;
 		}else
 			throw new InvalidFormatException();
@@ -62,11 +63,5 @@ public class CSV implements DataRepresentation {
 	@Override
 	public String getDescription() {
 		return "comma separated value";
-	}
-
-	@Override
-	public boolean checkFormat(String s){
-		String regex = "(.+?)(?:,\\s*|$)";
-		return s.matches(regex);
 	}
 }

--- a/src/main/java/data_representation/DataRepresentation.java
+++ b/src/main/java/data_representation/DataRepresentation.java
@@ -32,13 +32,7 @@ public interface DataRepresentation extends Iterator<Object>, HelpTarget, Serial
 	 * @throws InvalidFormatException thrown when the passed string does not conform to the test case format
 	 */
 	void parse(String s) throws InvalidFormatException;
-	/**
-	 * determines if the passed string conforms to the test case format
-	 * 
-	 * @param s the test case string to format check
-	 * @return true if the string matches the required format, otherwise false
-	 */
-	boolean checkFormat(String s);
+
 	/**
 	 * returns the test case being iterated over
 	 * 

--- a/src/main/java/data_representation/EventSequence.java
+++ b/src/main/java/data_representation/EventSequence.java
@@ -78,33 +78,6 @@ public class EventSequence implements DataRepresentation {
     }
 
     @Override
-    public boolean checkFormat(String s) {
-        if(s == null || s.length() == 0)
-            return false;
-        if (s.charAt(0) == '['){//there is an id at the start of the test case
-            if (s.charAt(1) == ']')
-                return false;
-            int i = 2;
-            for(;s.charAt(i) != ']';i++){}//find the end of the id
-            try {
-                Long.valueOf(s.substring(1, i));
-                s = s.substring(i+1).trim(); //remove the identifier from the test case string
-            }catch(NumberFormatException e) {
-                return false;
-            }
-        }
-
-        if(!s.startsWith("Start-"))
-            return false;
-        s = s.substring(6);
-
-        String[] stateEventList = s.split("-");
-        if(stateEventList.length == 1 && stateEventList[0].equals(""))
-            return false;
-        return true;
-    }
-
-    @Override
     public String getDescription() {
         return "reads in a dash-separated list of alternating events and states, but only stores the events";
     }

--- a/src/main/java/data_representation/EventStatePairs.java
+++ b/src/main/java/data_representation/EventStatePairs.java
@@ -82,34 +82,6 @@ public class EventStatePairs implements DataRepresentation {
     }
 
     @Override
-    public boolean checkFormat(String s) {
-        if(s == null || s.length() == 0)
-            return false;
-        if (s.charAt(0) == '['){//there is an id at the start of the test case
-            if (s.charAt(1) == ']')
-                return false;
-            int i = 2;
-            for(;s.charAt(i) != ']';i++){}//find the end of the id
-            try {
-                Long.valueOf(s.substring(1, i));
-                s = s.substring(i+1).trim(); //remove the identifier from the test case string
-            }catch(NumberFormatException e) {
-                return false;
-            }
-        }
-
-        if(!s.startsWith("Start-"))
-            return false;
-        s = s.substring(6);
-
-        String[] stateEventList = s.split("-");
-        if(stateEventList.length == 1 && stateEventList[0].equals(""))
-            return false;
-        //every event should have a following state, so length must be even
-        return stateEventList.length % 2 != 1;
-    }
-
-    @Override
     public String getDescription() {
         return "reads in a dash-separated list of alternating events and states, storing each event and resulting state as a tuple";
     }

--- a/src/main/java/data_representation/StateSequence.java
+++ b/src/main/java/data_representation/StateSequence.java
@@ -78,33 +78,6 @@ public class StateSequence implements DataRepresentation {
     }
 
     @Override
-    public boolean checkFormat(String s) {
-        if(s == null || s.length() == 0)
-            return false;
-        if (s.charAt(0) == '['){//there is an id at the start of the test case
-            if (s.charAt(1) == ']')
-                return false;
-            int i = 2;
-            for(;s.charAt(i) != ']';i++){}//find the end of the id
-            try {
-                Long.valueOf(s.substring(1, i));
-                s = s.substring(i+1).trim(); //remove the identifier from the test case string
-            }catch(NumberFormatException e) {
-                return false;
-            }
-        }
-
-        if(!s.startsWith("Start-"))
-            return false;
-        s = s.substring(6);
-
-        String[] stateEventList = s.split("-");
-        if(stateEventList.length == 1 && stateEventList[0].equals(""))
-            return false;
-        return true;
-    }
-
-    @Override
     public String getDescription() {
         return "reads in a dash-separated list of alternating events and states, but only stores the states";
     }

--- a/src/test/java/data_representation/CSVTest.java
+++ b/src/test/java/data_representation/CSVTest.java
@@ -107,23 +107,6 @@ public class CSVTest {
     }
 
     /**
-     * Test that the format comes back correct
-     */
-    @Test
-    public void testCheckCorrectFormat() {
-        assertTrue(csv.checkFormat(values.toString()));
-    }
-
-    /**
-     * Test that the format comes back incorrect
-     */
-    @Test
-    public void testCheckIncorrectFormat() {
-        assertFalse(csv.checkFormat(""));
-    }
-
-
-    /**
      * test that the getDescription method does return a description of the method
      */
     @Test

--- a/src/test/java/data_representation/EventSequenceTest.java
+++ b/src/test/java/data_representation/EventSequenceTest.java
@@ -36,7 +36,6 @@ public class EventSequenceTest {
     public void testOptionalIdentifier() throws InvalidFormatException {
         EventSequence withID = new EventSequence(testcase);
         EventSequence withoutID = new EventSequence(testcase.substring(5));
-        assertTrue(d.checkFormat(testcase.substring(5)));
         assertEquals(withID.toString(), "[43] " + withoutID.toString());
     }
 
@@ -67,28 +66,24 @@ public class EventSequenceTest {
     @Test
     /*Test that parse() completes successfully without throwing an exception*/
     public void testShortParse() throws InvalidFormatException {
-        assertTrue(d.checkFormat("Start-6"));
         d.parse("Start-6");
     }
 
     @Test(expected=InvalidFormatException.class)
     /*Tests that the parse() correctly throws an InvalidFormatException when given an invalid string*/
     public void testParseOnlyIdentifier() throws InvalidFormatException {
-        assertFalse(d.checkFormat("[7]"));
         d.parse("[7]");
     }
 
     @Test(expected=InvalidFormatException.class)
     /*Tests that the parse() correctly throws an InvalidFormatException when given an invalid string*/
     public void testParseNoStartState() throws InvalidFormatException {
-        assertFalse(d.checkFormat("6-7-8-9"));
         d.parse("6-7-8-9");
     }
 
     @Test(expected=InvalidFormatException.class)
     /*Tests that the parse() correctly throws an InvalidFormatException when given an invalid string*/
     public void testParseNoStates() throws InvalidFormatException {
-        assertFalse(d.checkFormat("Start-"));
         d.parse("Start-");
     }
 
@@ -102,7 +97,6 @@ public class EventSequenceTest {
     /*Tests that the parse() correctly throws an InvalidFormatException when given an invalid string*/
     public void testParseWithBadIdentifier() throws InvalidFormatException {
         String badID = "[] Start-1(0)-OffProtected-4-StoppedProtected-13-PlayingProtected-27-PausedProtected-56-xxxPlayingProtected";
-        assertFalse(d.checkFormat(badID));
         d.parse(badID);
     }
 
@@ -110,21 +104,7 @@ public class EventSequenceTest {
     /*Tests that the parse() correctly throws an InvalidFormatException when given an invalid string*/
     public void testParseWithNonNumberIdentifier() throws InvalidFormatException {
         String badID = "[b] Start-1(0)-OffProtected-4-StoppedProtected-13-PlayingProtected-27-PausedProtected-56-xxxPlayingProtected";
-        assertFalse(d.checkFormat(badID));
         d.parse(badID);
-    }
-
-    @Test
-    /*Test that the format comes back correct*/
-    public void testCheckCorrectFormat() {
-        assertTrue(d.checkFormat(testcase));
-    }
-
-    @Test
-    /*Test that the format comes back incorrect*/
-    public void testCheckIncorrectFormat() {
-        assertFalse(d.checkFormat(""));
-        assertFalse(d.checkFormat(null));
     }
 
     @Test

--- a/src/test/java/data_representation/EventStatePairsTest.java
+++ b/src/test/java/data_representation/EventStatePairsTest.java
@@ -37,7 +37,6 @@ public class EventStatePairsTest {
     public void testOptionalIdentifier() throws InvalidFormatException {
         EventStatePairs withID = new EventStatePairs(testcase);
         EventStatePairs withoutID = new EventStatePairs(testcase.substring(5));
-        assertTrue(d.checkFormat(testcase.substring(5)));
         assertEquals(withID.toString(), "[43] " + withoutID.toString());
     }
 
@@ -68,35 +67,30 @@ public class EventStatePairsTest {
     @Test
     /*Test that parse() completes successfully without throwing an exception*/
     public void testShortParse() throws InvalidFormatException {
-        assertTrue(d.checkFormat("Start-6-7"));
         d.parse("Start-6-7");
     }
 
     @Test(expected=InvalidFormatException.class)
     /*Tests that the parse() correctly throws an InvalidFormatException when given an invalid string*/
     public void testParseOnlyIdentifier() throws InvalidFormatException {
-        assertFalse(d.checkFormat("[7]"));
         d.parse("[7]");
     }
 
     @Test(expected=InvalidFormatException.class)
     /*Tests that the parse() correctly throws an InvalidFormatException when given an invalid string*/
     public void testParseNoStartState() throws InvalidFormatException {
-        assertFalse(d.checkFormat("6-7-8-9"));
         d.parse("6-7-8-9");
     }
 
     @Test(expected=InvalidFormatException.class)
     /*Tests that the parse() correctly throws an InvalidFormatException when given an invalid string*/
     public void testParseNoStates() throws InvalidFormatException {
-        assertFalse(d.checkFormat("Start-"));
         d.parse("Start-");
     }
 
     @Test(expected=InvalidFormatException.class)
     /*Tests that the parse() correctly throws an InvalidFormatException when given an invalid string*/
     public void testParseNoFollowingState() throws InvalidFormatException {
-        assertFalse(d.checkFormat("Start-6"));
         d.parse("Start-6");
     }
 
@@ -110,7 +104,6 @@ public class EventStatePairsTest {
     /*Tests that the parse() correctly throws an InvalidFormatException when given an invalid string*/
     public void testParseWithBadIdentifier() throws InvalidFormatException {
         String badID = "[] Start-1(0)-OffProtected-4-StoppedProtected-13-PlayingProtected-27-PausedProtected-56-xxxPlayingProtected";
-        assertFalse(d.checkFormat(badID));
         d.parse(badID);
     }
 
@@ -118,21 +111,7 @@ public class EventStatePairsTest {
     /*Tests that the parse() correctly throws an InvalidFormatException when given an invalid string*/
     public void testParseWithNonNumberIdentifier() throws InvalidFormatException {
         String badID = "[b] Start-1(0)-OffProtected-4-StoppedProtected-13-PlayingProtected-27-PausedProtected-56-xxxPlayingProtected";
-        assertFalse(d.checkFormat(badID));
         d.parse(badID);
-    }
-
-    @Test
-    /*Test that the format comes back correct*/
-    public void testCheckCorrectFormat() {
-        assertTrue(d.checkFormat(testcase));
-    }
-
-    @Test
-    /*Test that the format comes back incorrect*/
-    public void testCheckIncorrectFormat() {
-        assertFalse(d.checkFormat(""));
-        assertFalse(d.checkFormat(null));
     }
 
     @Test

--- a/src/test/java/data_representation/StateSequenceTest.java
+++ b/src/test/java/data_representation/StateSequenceTest.java
@@ -36,7 +36,6 @@ public class StateSequenceTest {
     public void testOptionalIdentifier() throws InvalidFormatException {
         StateSequence withID = new StateSequence(testcase);
         StateSequence withoutID = new StateSequence(testcase.substring(5));
-        assertTrue(d.checkFormat(testcase.substring(5)));
         assertEquals(withID.toString(), "[43] " + withoutID.toString());
     }
 
@@ -67,28 +66,24 @@ public class StateSequenceTest {
     @Test
     /*Test that parse() completes successfully without throwing an exception*/
     public void testShortParse() throws InvalidFormatException {
-        assertTrue(d.checkFormat("Start-6"));
         d.parse("Start-6");
     }
 
     @Test(expected=InvalidFormatException.class)
     /*Tests that the parse() correctly throws an InvalidFormatException when given an invalid string*/
     public void testParseOnlyIdentifier() throws InvalidFormatException {
-        assertFalse(d.checkFormat("[7]"));
         d.parse("[7]");
     }
 
     @Test(expected=InvalidFormatException.class)
     /*Tests that the parse() correctly throws an InvalidFormatException when given an invalid string*/
     public void testParseNoStartState() throws InvalidFormatException {
-        assertFalse(d.checkFormat("6-7-8-9"));
         d.parse("6-7-8-9");
     }
 
     @Test(expected=InvalidFormatException.class)
     /*Tests that the parse() correctly throws an InvalidFormatException when given an invalid string*/
     public void testParseNoStates() throws InvalidFormatException {
-        assertFalse(d.checkFormat("Start-"));
         d.parse("Start-");
     }
 
@@ -102,7 +97,6 @@ public class StateSequenceTest {
     /*Tests that the parse() correctly throws an InvalidFormatException when given an invalid string*/
     public void testParseWithBadIdentifier() throws InvalidFormatException {
         String badID = "[] Start-1(0)-OffProtected-4-StoppedProtected-13-PlayingProtected-27-PausedProtected-56-xxxPlayingProtected";
-        assertFalse(d.checkFormat(badID));
         d.parse(badID);
     }
 
@@ -110,21 +104,7 @@ public class StateSequenceTest {
     /*Tests that the parse() correctly throws an InvalidFormatException when given an invalid string*/
     public void testParseWithNonNumberIdentifier() throws InvalidFormatException {
         String badID = "[b] Start-1(0)-OffProtected-4-StoppedProtected-13-PlayingProtected-27-PausedProtected-56-xxxPlayingProtected";
-        assertFalse(d.checkFormat(badID));
         d.parse(badID);
-    }
-
-    @Test
-    /*Test that the format comes back correct*/
-    public void testCheckCorrectFormat() {
-        assertTrue(d.checkFormat(testcase));
-    }
-
-    @Test
-    /*Test that the format comes back incorrect*/
-    public void testCheckIncorrectFormat() {
-        assertFalse(d.checkFormat(""));
-        assertFalse(d.checkFormat(null));
     }
 
     @Test


### PR DESCRIPTION
the checkFormat function for DataRepresentations was only ever used in tests! this function would check whether a string matched the format for a given data representation, but this was not needed because the parse command would throw an exception if the string did not fit the data representation. In total, there were 34 usages of checkFormat in the code, but all in test cases!

 It would be a good idea to remove this, because it is one of the things you would need to implement when adding a new data representation. Obviously the work needed to add another data representation should be minimal, so it would be silly to make people implement a method that is never used in the system.