### PR TITLE
remove eclipse project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 # Eclipse settings
 .classpath
 .project
+.settings/
 
 # build directories
 out/

--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,0 @@
-eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
-org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
-org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
-org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
-org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.8


### PR DESCRIPTION
we've had this folder in the repository for a long time called ".settings" that has never been updated. by the name of its contents and the commit it was added, i'm pretty sure that they are project settings for eclipse, which we do not need here (and would be outdated anyways). This pull request deletes that folder, and adds the folder name to the gitignore